### PR TITLE
Update Golang version in docker-compose.yaml file to support Linux/ARM64, and release Linux/ARM64 quay/clair docker image

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -177,16 +177,20 @@ jobs:
         id: download
         with:
           name: release
-      - name: Build Release Container
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and Publish Release Container
         run: |
           d=$(mktemp -d)
           trap 'rm -rf "$d"' EXIT
           tar -xz -f ${{steps.download.outputs.download-path}}/clair.tar.gz --strip-components=1 -C "$d"
-          docker build --build-arg CLAIR_VERSION --tag "${TAG}" "$d"
-      - name: Publish Release Container
-        run: |
           docker login -u "${QUAY_USER}" -p '${{ secrets.QUAY_TOKEN }}' quay.io
-          docker push "${TAG}"
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg CLAIR_VERSION --tag "${TAG}" "$d"
 
   deploy-documentation:
     name: Deploy Documentation

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
       
   notifier:
     container_name: clair-notifier
-    image: quay.io/projectquay/golang:1.16
+    image: quay.io/projectquay/golang:1.17
     volumes:
       - "./:/src/clair/"
     environment:
@@ -93,7 +93,7 @@ services:
   # this should only be created and deleted via the make target "local-dev-notifier-test"
   notifier-test-mode:
     container_name: clair-notifier
-    image: quay.io/projectquay/golang:1.16
+    image: quay.io/projectquay/golang:1.17
     volumes:
       - "./:/src/clair/"
     environment:
@@ -112,7 +112,7 @@ services:
 
   indexer:
     container_name: clair-indexer
-    image: quay.io/projectquay/golang:1.16
+    image: quay.io/projectquay/golang:1.17
     volumes:
       - "./:/src/clair/"
     environment:
@@ -134,7 +134,7 @@ services:
   ## allows layer fetching over localhost
   indexer-quay:
     container_name: clair-indexer
-    image: quay.io/projectquay/golang:1.16
+    image: quay.io/projectquay/golang:1.17
     volumes:
       - "./:/src/clair/"
     environment:
@@ -156,7 +156,7 @@ services:
 
   matcher:
     container_name: clair-matcher
-    image: quay.io/projectquay/golang:1.16
+    image: quay.io/projectquay/golang:1.17
     volumes:
       - "./:/src/clair/"
     environment:


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** Following 2 files have been modified :

- docker-compose.yaml: Updated Golang version to 1.17 in the docker-compose.yaml file to support Linux/ARM64
- .github/workflows/cut-release.yaml: Added buildx utility to the workflows to release Quay/Clair docker image for Linux/ARM64

**2. Testing Detail:**
Please find my dockerhub repo here: <https://hub.docker.com/repository/docker/pshub/clair_multiarch/tags?page=1&ordering=last_updated>

I have used these images to run clair in the combo mode using clair as a docker container. I am able to get the vulnerabilities report on both the platforms.

**3. PR Description:** Here is my commit message :

- Updated Golang version to 1.17 in the docker-compose.yaml file to support Linux/ARM64
- Added buildx utility to the workflows to release Quay/Clair docker image for Linux/ARM64

Signed-off-by: odidev odidev@puresoftware.com

**4. Reviewer:** Akhand Pratap Singh

**Thanks
Rahul Aggarwal**